### PR TITLE
Favicon

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,7 +71,7 @@ module.exports  = function ( grunt ) {
                         '.htaccess',
                         '*.html',
                         'partials/{,*/}*.html',
-                        'img/{,*/}*.{webp}',
+                        'img/{,*/}*.*',
                         'css/{,*/}*.css',
                         'data/{,*/}*.*',
                         'CNAME'
@@ -194,7 +194,7 @@ module.exports  = function ( grunt ) {
                 files   : [{
                     expand  : true,
                     cwd     : '<%= config.app %>/img',
-                    src     : '{,*/}*.{png,jpg,jpeg,gif}',
+                    src     : '{,*/}*.{png,jpg,jpeg,gif,ico}',
                     dest    : '<%= config.dist %>/img'
                 }]
             }


### PR DESCRIPTION
Fixed bug that prevented the favicon from beign displayed in the application production version

## Testing
- [x] Run the `grunt build` command and open the `index.html` generated inside the `dist` folder
- [x] Check that the favicon is displayed correctly